### PR TITLE
Add autocomplete for time_zone to query_string

### DIFF
--- a/public/webpackShims/kb/api_2_0/query.js
+++ b/public/webpackShims/kb/api_2_0/query.js
@@ -361,7 +361,8 @@ define(['vendor/_'], function (_) {
         use_dis_max: {
           __one_of: [true, false]
         },
-        tie_breaker: 0
+        tie_breaker: 0,
+        time_zone: "+1:00"
       },
       simple_query_string: {
         __template: {


### PR DESCRIPTION
This commit adds autocomplete support for time_zone in query_string.

Relates elastic/elasticsearch#8164
