### PR TITLE
fix tab sizes

### DIFF
--- a/public/src/input.js
+++ b/public/src/input.js
@@ -164,7 +164,7 @@ function sendCurrentRequestToES() {
           if (mode === null || mode === "application/json") {
             // assume json - auto pretty
             try {
-              value = JSON.stringify(JSON.parse(value), null, 3);
+              value = JSON.stringify(JSON.parse(value), null, 2);
             }
             catch (e) {
 

--- a/public/src/output.js
+++ b/public/src/output.js
@@ -46,11 +46,17 @@ output.append = function (val, fold_previous, cb) {
 };
 
 output.$el = $el;
-output.getSession().setMode("ace/mode/text");
-output.getSession().setFoldStyle('markbeginend');
-output.getSession().setUseWrapMode(true);
+
+(function (session) {
+  session.setMode("ace/mode/text");
+  session.setFoldStyle('markbeginend');
+  session.setTabSize(2);
+  session.setUseWrapMode(true);
+}(output.getSession()));
+
 output.setShowPrintMargin(false);
 output.setReadOnly(true);
+
 if (settings) {
   settings.applyCurrentSettings(output);
 }


### PR DESCRIPTION
Currently the output is rendering the text with 3 spaces and the output editor is 4 spaces. Standardized on 2 spaces.
