### PR TITLE
prevent logo from hiding on tablet

### DIFF
--- a/public/css/sense.less
+++ b/public/css/sense.less
@@ -1,8 +1,8 @@
 @import "./sense.light.css";
 @import (reference) "~ui/styles/variables";
 
-#es_method {
-  width: 100px;
+nav.navbar .logo.hidden-sm {
+  display: block !important;
 }
 
 [sense-navbar] {

--- a/public/sense.js
+++ b/public/sense.js
@@ -14,8 +14,7 @@ require('./src/directives/senseNavbar');
 
 require('ui/chrome')
 .setBrand({
-  logo: 'url(/plugins/sense/icon.png) center no-repeat',
-  smallLogo: 'url(/plugins/sense/icon.png) left no-repeat'
+  logo: 'url(/plugins/sense/icon.png) center no-repeat'
 })
 .setRootTemplate(require('./index.html'))
 .setRootController('sense', 'SenseController');


### PR DESCRIPTION
Fixes #53

Prevents the `.hidden-sm` class from having an effect on the logo since the sense navbar is so sparse.
