### PR TITLE
juggle the serverUrl between angular and non-angular worlds better

### DIFF
--- a/public/src/controllers/SenseController.js
+++ b/public/src/controllers/SenseController.js
@@ -49,9 +49,4 @@ require('ui/modules')
       this.serverUrl = server;
     });
   });
-
-  // sync ui changes back to the es module
-  $scope.$watch('sense.serverUrl', (serverUrl) => {
-    es.setBaseUrl(serverUrl);
-  });
 });

--- a/public/src/directives/navbar.html
+++ b/public/src/directives/navbar.html
@@ -12,9 +12,10 @@
     aria-label="Server Name"
     class="form-control"
     ng-focus="navbar.updateServerUrlHistory()"
+    ng-blur="navbar.commitServerUrlFormModel()"
 
     sense-uib-typeahead="url for url in navbar.serverUrlHistory"
-    ng-model="sense.serverUrl"
+    ng-model="navbar.serverUrlFormModel"
     typeahead-append-to-body="true"
     typeahead-focus-first="false"
 

--- a/public/src/directives/senseNavbar.js
+++ b/public/src/directives/senseNavbar.js
@@ -1,4 +1,5 @@
 const history = require('../history');
+const es = require('../es');
 
 require('ui/modules')
 .get('app/sense')
@@ -7,13 +8,21 @@ require('ui/modules')
     restrict: 'A',
     template: require('./navbar.html'),
     controllerAs: 'navbar',
-    controller: function SenseNavbarController($element) {
+    controller: function SenseNavbarController($scope, $element) {
       this.serverUrlHistory = [];
       this.updateServerUrlHistory = function () {
         this.serverUrlHistory = history.getHistoricalServers();
       };
 
       this.updateServerUrlHistory();
+
+      this.commitServerUrlFormModel = () => {
+        es.setBaseUrl(this.serverUrlFormModel);
+      };
+
+      $scope.$watch('sense.serverUrl', (serverUrl) => {
+        this.serverUrlFormModel = serverUrl;
+      });
     }
   };
 });


### PR DESCRIPTION
Currently when you type into the serverUrl text box quickly the url gets reset several times and it seems to be caused by the introduction of `$scope.$evalAsync` when fixing #52.

This prevents that issue by only updating the es.serverUrl when the input is blurred.
