### PR TITLE
use more resiliant resize method

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -122,28 +122,15 @@ history.restoreFromHistory = function applyHistoryElem(req) {
   input.focus();
 };
 
-(function stuffThatsTooHardWithCSS() {
-  var delay = null;
+function resize() {
+  input.resize();
+  output.resize();
+}
 
-  function update() {
-    if (delay) {
-      delay = clearTimeout(delay);
-    }
-
-    input.resize(true);
-    output.resize(true);
-  }
-
-  update();
-
-  // and when the window resizes (once every 500 ms)
-  $(window)
-  .resize(function (event) {
-    if (!delay && event.target === window) {
-      delay = setTimeout(update, 500);
-    }
-  });
-}());
+resize();
+$(window).resize((event) => {
+  if (event.target === window) resize();
+});
 
 loadSavedState();
 setupAutosave();

--- a/public/src/input_resize.js
+++ b/public/src/input_resize.js
@@ -34,8 +34,8 @@ module.exports = function (input, output) {
         .one('mouseup', function () {
           $resizer.removeClass('active');
           $(this).off('mousemove', onMove);
-          input.resize(true);
-          output.resize(true);
+          input.resize();
+          output.resize();
         });
     });
 

--- a/public/src/output.js
+++ b/public/src/output.js
@@ -2,12 +2,14 @@ let ace = require('ace');
 let $ = require('jquery');
 let settings = require('./settings');
 let OutputMode = require('./sense_editor/mode/output');
+const smartResize = require('./smart_resize');
 
 var $el = $("#output");
 var output = ace.require('ace/ace').edit($el[0]);
 
 var outputMode = new OutputMode.Mode();
 
+output.resize = smartResize(output);
 output.update = function (val, mode, cb) {
   if (typeof mode === 'function') {
     cb = mode;

--- a/public/src/sense_editor/editor.js
+++ b/public/src/sense_editor/editor.js
@@ -6,6 +6,7 @@ let RowParser = require('./row_parser');
 let InputMode = require('./mode/input');
 let utils = require('../utils');
 let es = require('../es');
+const smartResize = require('../smart_resize');
 
 function isInt(x) {
   return !isNaN(parseInt(x, 10));
@@ -58,6 +59,7 @@ function SenseEditor($el) {
 
   // mixin the RowParser
   editor.parser = new RowParser(editor);
+  editor.resize = smartResize(editor);
 
   // dirty check for tokenizer state, uses a lot less cycles
   // than listening for tokenizerUpdate

--- a/public/src/smart_resize.js
+++ b/public/src/smart_resize.js
@@ -3,17 +3,14 @@ import { throttle } from 'lodash';
 module.exports = function (editor) {
   let resize = editor.resize;
   let lastDemensions = [];
+  let timeout = null;
 
   let checkDelay = 250;
-  let recheckDelay = 500;
-  let stableAfter = 5000;
-  let timeouts = [];
-
   let stableChecks = 0;
-  let maxStableChecks = stableAfter / recheckDelay;
+  let maxStableChecks = 20;
 
-  function exec() {
-    timeouts.splice(0).map(clearTimeout);
+  function check() {
+    clearTimeout(timeout);
 
     const $container = editor.$el.parent();
     const demensions = [$container.width(), $container.height()];
@@ -29,17 +26,17 @@ module.exports = function (editor) {
     }
 
     if (stableChecks < maxStableChecks) {
-      scheduleRecheck();
+      scheduleCheck();
     }
+  }
+
+  function scheduleCheck() {
+    if (!timeout) timeout = setTimeout(check, checkDelay);
   }
 
   function requestResize() {
     stableChecks = 0;
-    if (!timeouts[0]) timeouts[0] = setTimeout(exec, checkDelay);
-  }
-
-  function scheduleRecheck() {
-    if (!timeouts[1]) timeouts[1] = setTimeout(exec, recheckDelay);
+    scheduleCheck();
   }
 
   return requestResize;

--- a/public/src/smart_resize.js
+++ b/public/src/smart_resize.js
@@ -1,0 +1,30 @@
+import { throttle } from 'lodash';
+
+module.exports = function (editor) {
+
+  let lastDemensions = [];
+  let resize = editor.resize;
+  let throttle = 250;
+  let timeout = null;
+
+  function exec() {
+    timeout = null;
+
+    const $container = editor.$el.parent();
+    const demensions = [$container.width(), $container.height()];
+    const [ width, height ] = demensions;
+    const [ lastWidth, lastHieght ] = lastDemensions;
+    lastDemensions = demensions;
+
+    if (width !== lastWidth || height !== lastHieght) {
+      resize.call(editor, true);
+      schedule();
+    }
+  }
+
+  function schedule() {
+    if (!timeout) timeout = setTimeout(exec, throttle);
+  }
+
+  return schedule;
+};


### PR DESCRIPTION
Fixes #70 

Since some browsers may not flex the elements which hold the editors immediately, allow calls to editor.resize() to re-run if their container changes size soon after resize occurred.