### PR TITLE
[welcome] prevent scrolling in the welcome editor

### DIFF
--- a/public/src/directives/senseHelpExample.js
+++ b/public/src/directives/senseHelpExample.js
@@ -1,5 +1,5 @@
 const SenseEditor = require('../sense_editor/editor');
-const exampleText = require('raw!./helpExample.txt');
+const exampleText = require('raw!./helpExample.txt').trim();
 
 require('ui/modules')
 .get('app/sense')
@@ -10,6 +10,7 @@ require('ui/modules')
       $el.text(exampleText);
       $scope.editor = new SenseEditor($el);
       $scope.editor.setReadOnly(true);
+      $scope.editor.$blockScrolling = Infinity;
 
       $scope.$on('$destroy', function () {
         if ($scope.editor) $scope.editor.destroy();


### PR DESCRIPTION
The editor in the welcome screen got an extra new-line at the end of the file (editor settings) which caused the ace editor to scroll. I've forced scrolling to be disabled and trimmed the editor text for good measure.

This allows scrolling to the bottom of the welcome editor is possible even in a very constrained space (because the editor doesn't steal scroll events).