### PR TITLE
Implement proxy using POST method

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ module.exports = function (kibana) {
   let src = resolve(__dirname, 'public/src/');
   let { existsSync } = require('fs');
   const { startsWith, endsWith } = require('lodash');
+  let Wreck = require('wreck');
+  let { fromNode: fn } = require('bluebird');
 
   const apps = [
     {
@@ -44,42 +46,51 @@ module.exports = function (kibana) {
 
     init: function (server, options) {
       const filters = options.proxyFilter.map(str => new RegExp(str));
+      const usingSsl = !!(server.config().get('server.ssl.cert') && server.config().get('server.ssl.key'));
 
-      // http://hapijs.com/api/8.8.1#route-configuration
+      const proxyErr = function (reply, status, uri, message) {
+        reply(`Error connecting to '${uri}':\n\n${message}`).code(502).type('text/plain');
+      };
+
       server.route({
-        path: '/api/sense/proxy',
-        method: ['*', 'GET'],
+        path: '/api/sense/exec',
+        method: 'POST',
         config: {
-          handler: {
-            proxy: {
-              mapUri: function (req, cb) {
-                let { uri } = req.query;
-                if (!uri) {
-                  cb(Boom.badRequest('URI is a required param.'));
-                  return;
-                }
+          validate: {
+            query: Joi.object().keys({
+              uri: Joi.string().uri().required(),
+              method: Joi.valid('HEAD', 'GET', 'PUT', 'POST', 'DELETE').required(),
+            }),
+          },
+          payload: {
+            parse: false,
+            output: 'stream',
+          },
+        },
+        handler(req, reply) {
+          let { method, uri } = req.query;
 
-                if (!filters.some(re => re.test(uri))) {
-                  const err = Boom.forbidden();
-                  err.output.payload = "Error connecting to '" + uri + "':\n\nUnable to send requests to that url.";
-                  err.output.headers['content-type'] = 'text/plain';
-                  cb(err);
-                  return;
-                }
-
-                cb(null, uri);
-              },
-              passThrough: true,
-              xforward: true,
-              onResponse: function (err, res, request, reply, settings, ttl) {
-                if (err != null) {
-                  reply("Error connecting to '" + request.query.uri + "':\n\n" + err.message).type("text/plain").statusCode = 502;
-                } else {
-                  reply(null, res);
-                }
-              }
-            }
+          if (!filters.some(re => re.test(uri))) {
+            return proxyErr(reply, 403, uri, 'Unable to send requests to that url.');
           }
+
+          const xForwarding = {};
+          if (req.info.remoteAddress && req.info.remotePort) {
+            xForwarding['x-forwarded-for'] = req.info.remoteAddress;
+            xForwarding['x-forwarded-port'] = req.info.remotePort;
+            xForwarding['x-forwarded-proto'] = usingSsl;
+          }
+
+          Wreck.request(method, uri, {
+            payload: req.payload,
+            headers: {
+              ...req.headers,
+              ...xForwarding,
+            }
+          }, function (err, upResp) {
+            if (err) proxyErr(reply, 503, uri, err.message);
+            else reply(null, upResp);
+          });
         }
       });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "gruntify-eslint": "^1.2.0",
     "jit-grunt": "^0.9.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "x-forwarded-from-hapi": "0.0.1"
+  },
   "license": "Apache-2.0"
 }

--- a/public/src/es.js
+++ b/public/src/es.js
@@ -30,18 +30,15 @@ module.exports.send = function (method, path, data, server, disable_auth_alert) 
 
   // delayed loading for circular references
   var settings = require("./settings");
-
   var options = {
-    url: '/api/sense/proxy?uri=' + encodeURIComponent(path),
-    data: method == "GET" ? null : data,
+    url: `/api/sense/exec?uri=${encodeURIComponent(path)}&method=${encodeURIComponent(method)}`,
+    method: 'POST',
+    data: method === 'GET' ? null : data,
     cache: false,
-    crossDomain: true,
-    type: method,
     password: password,
     username: uname,
-    dataType: "text", // disable automatic guessing
+    dataType: 'text', // disable automatic guessing
   };
-
 
   $.ajax(options).then(
     function (data, textStatus, jqXHR) {


### PR DESCRIPTION
Fixes #76

The current proxy behaves as a proxy should and sends the request to its upstream counterpart in almost the exact way that it received it. These changes update the proxy to only run over POST and operate more like a API endpoint than a proxy. The endpoint now takes a URI, a http method, and a request body. It will combine those into a request to the URI and return the response just like the proxy did. This means that methods like "HEAD" don't need special treatment and has security benefits.
