### PR TITLE
Add query string options for the segments API

### DIFF
--- a/api_server/es_2_0/indices.js
+++ b/api_server/es_2_0/indices.js
@@ -70,7 +70,11 @@ module.exports = function (api) {
     patterns: [
       "{indices}/_segments",
       "_segments"
-    ]
+    ],
+    url_params: {
+      "human": "__flag__",
+      "verbose": "__flag__"
+    }
   });
 
   api.addEndpointDescription('_recovery', {


### PR DESCRIPTION
The segments API was missing `human` and `verbose`
