### PR TITLE
ajax paths - use relative paths to allow Kibana basePath config

### DIFF
--- a/public/src/es.js
+++ b/public/src/es.js
@@ -32,7 +32,7 @@ module.exports.send = function (method, path, data, server, disable_auth_alert) 
   var settings = require("./settings");
 
   var options = {
-    url: '/api/sense/proxy?uri=' + encodeURIComponent(path),
+    url: '../api/sense/proxy?uri=' + encodeURIComponent(path),
     data: method == "GET" ? null : data,
     cache: false,
     crossDomain: true,

--- a/public/src/kb.js
+++ b/public/src/kb.js
@@ -220,7 +220,7 @@ function loadApisFromJson(json, urlParametrizedComponentFactories, bodyParametri
 function setActiveApi(api) {
   if (_.isString(api)) {
     $.ajax({
-        url: '/api/sense/api_server?sense_version=' + encodeURIComponent('@@SENSE_VERSION') + "&apis=" + encodeURIComponent(api),
+        url: '../api/sense/api_server?sense_version=' + encodeURIComponent('@@SENSE_VERSION') + "&apis=" + encodeURIComponent(api),
         dataType: "json", // disable automatic guessing
       }
     ).then(


### PR DESCRIPTION
If Kibana has the `server.basePath` setting set, i.e. if the user is
running Kibana behind a reverse proxy, then the absolute paths to server
resources will not work. By changing them to relative, we can still
access the server resources without possibly clobbering a basePath in
the URL, which would lead to a 404 error.