### PR TITLE
Fixing doc to match reality

### DIFF
--- a/public/src/directives/welcome.html
+++ b/public/src/directives/welcome.html
@@ -2,7 +2,7 @@
 
 <h4>Quick intro to the UI</h4>
 
-<p>Sense is split into two panes: an editor pane (white) and a response pane (black).
+<p>Sense is split into two panes: an editor pane (left) and a response pane (right).
   Use the editor to type requests and submit them to Elasticsearch. The results will be displayed in
   the response pane on the right side.
 </p>


### PR DESCRIPTION
The welcome doc says the response pane is black but it is actually white (same as the editor pane). So using left/right instead of white/black to distinguish the editor/response panes.