### PR TITLE
Updates help file with correct expand-all command

### DIFF
--- a/public/src/directives/help.html
+++ b/public/src/directives/help.html
@@ -20,7 +20,9 @@
       <dt>Ctrl/Cmd + Alt + L</dt>
       <dd>Collapse/expand current scope.</dd>
       <dt>Ctrl/Cmd + Option + 0</dt>
-      <dd>Collapse all scopes but the current one. Expand by adding a shift.</dd>
+      <dd>Collapse all scopes but the current one.
+      <dt>Option + Shift + 0</dt>
+      <dd>Expand all scopes.</dd>
     </dl>
     <dl class="dl-horizontal">
       <dt></dt>


### PR DESCRIPTION
Received this email from @sfingerhut:

---

Didn’t know where else to inform about this… I’m hoping you know where to take this.

In the Sense “Help panel” under “Keyboard tips” the collapse/expand function tells to add a shift to the ctrl/cmd + Option + 0 to expand the complete scope. After some frustrating 20 seconds where this didn’t work - I discovered that the function instead is triggered by Option + shift + 0 (without the ctrl/cmd and where Option equals alt on a Windows 10 machine).

Hope to see this correction in a future version of Sense J

---
