### PR TITLE
URI-encode query string param values before sending request to proxy

### DIFF
--- a/public/src/input.js
+++ b/public/src/input.js
@@ -11,6 +11,7 @@ let storage = require('./storage');
 let utils = require('./utils');
 let es = require('./es');
 let history = require('./history');
+const qs = require('querystring');
 
 var input = new SenseEditor($('#editor'));
 
@@ -117,13 +118,8 @@ function sendCurrentRequestToES() {
       let result = url;
       let [ endpoint, queryString ] = url.split('?');
       if (queryString) {
-        const params = queryString.split('&');
-        params.forEach((param, index) => {
-          const [ key, value ] = param.split('=');
-          params[index] = `${key}=${encodeURIComponent(value)}`;
-        });
-        queryString = params.join('&');
-        result = `${endpoint}?${queryString}`;
+        const parsedQueryString = qs.parse(queryString);
+        result = `${endpoint}?${qs.stringify(parsedQueryString)}`;
       }
       return result;
     }

--- a/public/src/input.js
+++ b/public/src/input.js
@@ -11,7 +11,7 @@ let storage = require('./storage');
 let utils = require('./utils');
 let es = require('./es');
 let history = require('./history');
-const qs = require('querystring');
+const url = require('url');
 
 var input = new SenseEditor($('#editor'));
 
@@ -114,14 +114,12 @@ function sendCurrentRequestToES() {
 
     var isFirstRequest = true;
 
-    function urlEncodeQueryStringParamValues(url) {
-      let result = url;
-      let [ endpoint, queryString ] = url.split('?');
-      if (queryString) {
-        const parsedQueryString = qs.parse(queryString);
-        result = `${endpoint}?${qs.stringify(parsedQueryString)}`;
+    function urlEncodeQueryStringParamValues(elasticsearchUrl) {
+      const parsedUrl = url.parse(elasticsearchUrl, true);
+      if (parsedUrl.query) {
+        parsedUrl.search = undefined; // so the encoded query string in parsedUrl.query is used
       }
-      return result;
+      return url.format(parsedUrl);
     }
 
     var sendNextRequest = function () {

--- a/public/src/input.js
+++ b/public/src/input.js
@@ -113,6 +113,21 @@ function sendCurrentRequestToES() {
 
     var isFirstRequest = true;
 
+    function urlEncodeQueryStringParamValues(url) {
+      let result = url;
+      let [ endpoint, queryString ] = url.split('?');
+      if (queryString) {
+        const params = queryString.split('&');
+        params.forEach((param, index) => {
+          const [ key, value ] = param.split('=');
+          params[index] = `${key}=${encodeURIComponent(value)}`;
+        });
+        queryString = params.join('&');
+        result = `${endpoint}?${queryString}`;
+      }
+      return result;
+    }
+
     var sendNextRequest = function () {
       if (req_id != CURRENT_REQ_ID) {
         return;
@@ -122,7 +137,7 @@ function sendCurrentRequestToES() {
         return;
       }
       var req = requests.shift();
-      var es_path = req.url;
+      var es_path = urlEncodeQueryStringParamValues(req.url);
       var es_method = req.method;
       var es_data = req.data.join("\n");
       if (es_data) {


### PR DESCRIPTION
Resolves #151 

To test this, issue the following request: `GET _analyze?tokenizer=standard&text=cat dog`

Prior to this PR, this request would fail with the following response:

```json
{
   "statusCode": 400,
   "error": "Bad Request",
   "message": "child \"uri\" fails because [\"uri\" must be a valid uri]",
   "validation": {
      "source": "query",
      "keys": [
         "uri"
      ]
   }
}
```

With this PR, this request should succeed with the following response:
```json
{
  "tokens": [
    {
      "token": "cat",
      "start_offset": 0,
      "end_offset": 3,
      "type": "<ALPHANUM>",
      "position": 0
    },
    {
      "token": "dog",
      "start_offset": 4,
      "end_offset": 7,
      "type": "<ALPHANUM>",
      "position": 1
    }
  ]
}
```

